### PR TITLE
Properly daemonize eye process on launch

### DIFF
--- a/bin/eye
+++ b/bin/eye
@@ -231,7 +231,8 @@ private
     args = []
     args += ['-l', options[:logger]] if options[:logger]
 
-    pid = Process.spawn(ruby_path, loader_path, *args, :out => '/dev/null', :err => '/dev/null', :in => '/dev/null')
+    pid = Process.spawn(ruby_path, loader_path, *args, :out => '/dev/null', :err => '/dev/null', :in => '/dev/null',
+                        :chdir => '/', :pgroup => true)
     Process.detach(pid)
     File.open(Eye::Settings.pid_path, 'w'){|f| f.write(pid) }
 


### PR DESCRIPTION
The daemonization code was not releasing the current dir and not changing the process group. This leads to issues in determinate circumstances.

For example, running eye from ssh with an allocated pty would start and kill it immediately:

ssh root@host -t "eye load /etc/eye.conf"

Without the pty it works:

ssh root@host "eye load /etc/eye.conf"
