### PR TITLE
Do not downcase path to eye log file

### DIFF
--- a/lib/eye/logger.rb
+++ b/lib/eye/logger.rb
@@ -42,7 +42,7 @@ class Eye::Logger
     attr_reader :dev, :log_level
 
     def link_logger(dev)
-      @dev = dev ? dev.to_s.downcase : nil
+      @dev = dev ? dev.to_s : nil
       @dev_fd = @dev
 
       @dev_fd = STDOUT if @dev == 'stdout'


### PR DESCRIPTION
Allows directory path with upper case letters, too.

Why is this downcased exactly?
