### PR TITLE
allow deleting variables from environment

### DIFF
--- a/lib/eye/system.rb
+++ b/lib/eye/system.rb
@@ -156,7 +156,7 @@ module Eye::System
       env = {}
 
       (config[:environment] || {}).each do |k,v|
-        env[k.to_s] = v.to_s if v
+        env[k.to_s] = v && v.to_s
       end
 
       env

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -34,11 +34,13 @@ describe "Eye::System" do
     Eye::System.send(:prepare_env, {:environment => {'A' => 'B'}, :working_dir => "/tmp"}).should include({'A' => 'B'})
 
     r = Eye::System.send(:prepare_env, {:environment => {'A' => [], 'B' => {}, 'C' => nil, 'D' => 1, 'E' => '2'}})
-    r['A'].should == '[]'
-    r['B'].should == '{}'
-    r['C'].should == nil
-    r['D'].should == '1'
-    r['E'].should == '2'
+    r.should eq(
+      'A' => '[]',
+      'B' => '{}',
+      'C' => nil,
+      'D' => '1',
+      'E' => '2'
+    )
   end
 
   it "set spawn_options" do


### PR DESCRIPTION
I have found a bug when I was trying to spawn a process with `bundle exec` from Eye that is also started by `bundle exec` but from different Ruby and with different set of gems. For this purpose the environment of  spawned process should not contain `BUNDLE_*` and `RUBYOPT` (the very same thing that bundler does in `Bundler#with_clean_env` - https://github.com/bundler/bundler/blob/master/lib/bundler.rb#L220)

But when I tried to use `env "RUBYOPT" => nil` it just simply got ignored - I believe that there is wrong condition in the `prepare_env` method - it's not passing the `nil` variable to the `#spawn` method as it should but it simply ignores it.

I strongly believe that the original intention was to allow the `nil` values (there is actually no reason for the opposite) and it's also covered by a test, which unfortunately is not testing things properly. The offending line `r['C'].should == nil` is wrong as this line passes not only when 'C' is nil (which was probably purpose of this assertion) but also it successfully passes when the 'C' key is not present in the hash (which is the actual case).

And by the way - thanks for the great gem!
