### PR TITLE
Sort __default__ out without trusting the Z

### DIFF
--- a/lib/eye/application.rb
+++ b/lib/eye/application.rb
@@ -23,7 +23,7 @@ class Eye::Application
 
   # sort processes in name order
   def resort_groups
-    @groups = @groups.sort_by{|gr| gr.name == '__default__' ? 'zzzzz' : gr.name }
+    @groups = @groups.sort { |a,b| a.name == '__default__' ? 1 : b.name == '__default__' ? -1 : a.name <=> b.name }
   end
 
   def status_data(debug = false)


### PR DESCRIPTION
Not a major change, I just found a couple cases where I wanted something to appear at the end of the list and the `'zzzzz'` made me sleepy. Sorting by the actual order, although adding a tiny bit more logic, felt a bit cleaner.
