### PR TITLE
Check config for ruby binary

### DIFF
--- a/lib/eye/cli/server.rb
+++ b/lib/eye/cli/server.rb
@@ -14,7 +14,7 @@ private
 
   def ruby_path
     require 'rbconfig'
-    RbConfig::CONFIG['bindir'] + '/ruby'
+    File.join RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']
   end
 
   def ensure_loader_path


### PR DESCRIPTION
When ruby is installed as a different filename (e.g. ruby1.9), eye would pick up the wrong ruby executable.  This checks RbConfig for the current binary name.
