### PR TITLE
Improved sidekiq example

### DIFF
--- a/examples/sidekiq.eye
+++ b/examples/sidekiq.eye
@@ -6,7 +6,7 @@ module Eye
       rails_env = env['RAILS_ENV']
     
       process(name) do
-        start_command "ruby ./bin/sidekiq -e #{rails_env} -C ./config/sidekiq.#{rails_env}.yml"
+        start_command "bin/sidekiq -e #{rails_env} -C ./config/sidekiq.#{rails_env}.yml"
         pid_file "tmp/pids/#{name}.pid"
         stdall "log/#{name}.log"
         daemonize true


### PR DESCRIPTION
According to my comments from #77 
- [x] use proper signals for stopping sidekiq
- [x] removed `ruby ./` from the beginning of `start_command`
