### PR TITLE
Prevent Eye::Local.dir from being set if EYE_HOME presents

### DIFF
--- a/bin/leye
+++ b/bin/leye
@@ -11,6 +11,8 @@ unless Eye::Local.eyefile
   exit 1
 end
 
-Eye::Local.dir = File.dirname(Eye::Local.eyefile)
+unless ENV.key? 'EYE_HOME'
+  Eye::Local.dir = File.dirname(Eye::Local.eyefile)
+end
 Eye::Local.local_runner = true
 Eye::Cli.start


### PR DESCRIPTION
Hi!

I really think that eye `home` directory and `Eyefile` must be decoupled. So if we have `EYE_HOME` when running `leye` then we should not infer eye home directory from `Eyefile` path.

It also can be seen that existing logic is buggy: when passing `EYE_HOME` to leye the `.eyeconfig` path is infered from `home` but `socket_path` and `pid_path` are not because of `@dir` memoization.

If interested my initial goal was to store eye's pid and socket in shared directory created by capistrano. Am I doing anything wrong?