### PR TITLE
Add proxy support for HTTP checker

### DIFF
--- a/lib/eye/checker/http.rb
+++ b/lib/eye/checker/http.rb
@@ -6,6 +6,7 @@ class Eye::Checker::Http < Eye::Checker::Defer
   #  :url => "http://127.0.0.1:3000/", :kind => :success, :pattern => /OK/, :timeout => 3.seconds
 
   param :url,           String, true
+  param :proxy_url,     String
   param :pattern,       [String, Regexp]
   param :kind,          [String, Fixnum, Symbol]
   param :timeout,       [Fixnum, Float]
@@ -18,6 +19,7 @@ class Eye::Checker::Http < Eye::Checker::Defer
     super
 
     @uri = URI.parse(url)
+    @proxy_uri = URI.parse(proxy_url) if proxy_url
     @kind = case kind
               when Fixnum then Net::HTTPResponse::CODE_TO_OBJ[kind]
               when String, Symbol then Net.const_get("HTTP#{kind.to_s.camelize}") rescue Net::HTTPSuccess
@@ -80,15 +82,25 @@ class Eye::Checker::Http < Eye::Checker::Defer
   end
 
   def session
-    Net::HTTP.new(@uri.host, @uri.port).tap do |session|
+    net_http.tap do |session|
       if @uri.scheme == 'https'
         require 'net/https'
         session.use_ssl = true
         session.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
+
       session.open_timeout = @open_timeout
       session.read_timeout = @read_timeout
     end
   end
 
+  private
+
+  def net_http
+    if @proxy_uri
+      Net::HTTP.new(@uri.host, @uri.port, @proxy_uri.host, @proxy_uri.port)
+    else
+      Net::HTTP.new(@uri.host, @uri.port)
+    end
+  end
 end

--- a/lib/eye/checker/http.rb
+++ b/lib/eye/checker/http.rb
@@ -79,8 +79,6 @@ class Eye::Checker::Http < Eye::Checker::Defer
     end
   end
 
-private
-
   def session
     Net::HTTP.new(@uri.host, @uri.port).tap do |session|
       if @uri.scheme == 'https'

--- a/spec/checker/http_spec.rb
+++ b/spec/checker/http_spec.rb
@@ -184,6 +184,15 @@ describe "Eye::Checker::Http" do
         expect(subject.read_timeout).to eq(15)
       end
     end
+
+    context "when proxy is given" do
+      let(:http_checker) { chhttp(proxy_url: 'http://localhost:1080') }
+
+      it "sets proxy accoring to given value" do
+        expect(subject.proxy_address).to eq('localhost')
+        expect(subject.proxy_port).to eq(1080)
+      end
+    end
   end
 
 end

--- a/spec/checker/http_spec.rb
+++ b/spec/checker/http_spec.rb
@@ -122,4 +122,68 @@ describe "Eye::Checker::Http" do
     end
   end
 
+  describe "session" do
+    subject { http_checker.session }
+
+    context "when scheme is http" do
+      let(:http_checker) { chhttp }
+
+      it "does not use SSL" do
+        expect(subject.use_ssl?).to be_false
+      end
+    end
+
+    context "when scheme is https" do
+      let(:http_checker) { chhttp(url: "https://google.com") }
+
+      it "uses SSL" do
+        expect(subject.use_ssl?).to be_true
+      end
+
+      it "sets veryfy_mode" do
+        expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+      end
+    end
+
+    context "when 'open_timeout' is given" do
+      let(:http_checker) { chhttp(open_timeout: 42) }
+
+      it "sets open_timout according to given value" do
+        expect(subject.open_timeout).to eq(42)
+      end
+    end
+
+    context "when 'open_timeout' is not given" do
+      let(:http_checker) { chhttp(open_timeout: nil) }
+
+      it "takes 3 seconds by default" do
+        expect(subject.open_timeout).to eq(3)
+      end
+    end
+
+    context "when 'read_timeout' is given" do
+      let(:http_checker) { chhttp(read_timeout: 42) }
+
+      it "sets read_timeout according to given value" do
+        expect(subject.read_timeout).to eq(42)
+      end
+    end
+
+    context "when 'timeout' is given" do
+      let(:http_checker) { chhttp(timeout: 42) }
+
+      it "sets read_timeout according to given value" do
+        expect(subject.read_timeout).to eq(42)
+      end
+    end
+
+    context "when neither 'read_timeout' nor 'timeout' is given" do
+      let(:http_checker) { chhttp(read_timeout: nil, timeout: nil) }
+
+      it "takes 15 secods by default" do
+        expect(subject.read_timeout).to eq(15)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Allows to do:

```ruby
check :http, url: 'http://127.0.0.1:33233/hello', proxy_url: 'http://proxy.local:1080',  pattern: /World/, every: 5.seconds, timeout: 1.second
```
We use it to monitor health of proxy servers in our production environment.

Also some specs for `Checker::Http#session` are added. The testing method is questionable, because if one needs to test a private method, then it is usually a sign that responsibility of the method should be extracted to a separate class. But in this case I just made the method public.

So if you think the proposed way is wrong, any suggestions are much appreciated.

Thanks.