### PR TITLE
Using getfqdn versus gethostname

### DIFF
--- a/lib/eye/local.rb
+++ b/lib/eye/local.rb
@@ -67,7 +67,7 @@ module Eye::Local
     def host
       @host ||= begin
         require 'socket'
-        Socket.gethostname
+        Socket.getfqdn
       end
     end
 


### PR DESCRIPTION
Possibly a personal preference, but I think most who would be using this in multiple environments would actually need to the fqdn returned, rather than just the short hostname.