### PR TITLE
Handle quoted environment values in load_env

### DIFF
--- a/lib/eye/utils.rb
+++ b/lib/eye/utils.rb
@@ -52,7 +52,7 @@ module Eye::Utils
       e = e.gsub(%r[#.+$], '').strip
       next unless e.include?('=')
       k, v = e.split('=', 2)
-      h[k] = v
+      h[k] = v.gsub(%r/^["']+(.*)["']+$/, '\1')
     end
     h
   end

--- a/spec/dsl/process_spec.rb
+++ b/spec/dsl/process_spec.rb
@@ -551,7 +551,7 @@ end
           load_env "#{fixture('dsl/env1')}"
         end
       E
-      Eye::Dsl.parse_apps(conf)['bla'][:environment].should == {"A"=>"11", "B" => "12=13", "E" => "55"}
+      Eye::Dsl.parse_apps(conf)['bla'][:environment].should == {"A"=>"11", "B" => "12=13", "E" => "55", "F" => "stuff", "G" => "more"}
     end
 
     it "file not found" do

--- a/spec/fixtures/dsl/env1
+++ b/spec/fixtures/dsl/env1
@@ -3,5 +3,7 @@ B=12=13
 # C=1
 #D
 E=55 # D=11
+F="stuff"
+G='more'
 
 a


### PR DESCRIPTION
This allows the env file to be compatible with a shell sourced env file.