### PR TITLE
fix(log): add human readable values to children_memory log

### DIFF
--- a/lib/eye/checker/children_memory.rb
+++ b/lib/eye/checker/children_memory.rb
@@ -3,10 +3,18 @@ class Eye::Checker::ChildrenMemory < Eye::Checker::Measure
   # check :children_memory, :every => 30.seconds, :below => 400.megabytes
   #   monitor_children should be enabled
 
+  def check_name
+    @check_name ||= "children_memory(#{measure_str})"
+  end
+
   def get_value
     process.children.values.inject(0) do |sum, ch|
       sum + Eye::SystemResources.memory(ch.pid).to_i
     end
+  end
+
+  def human_value(value)
+    "#{value.to_i / 1024 / 1024}Mb"
   end
 
 end


### PR DESCRIPTION
Before
```
2021.11.12 18:38:49 INFO  -- [firefox:marionette] check:children_memory [211542016] => OK
```
After
```
2021.11.12 20:02:20 INFO  -- [firefox:marionette] check:children_memory(<450Mb) [296Mb] => OK
```